### PR TITLE
Add decision helper and integrate into master pipeline

### DIFF
--- a/decision_maker.py
+++ b/decision_maker.py
@@ -1,0 +1,57 @@
+"""Simple trading decision logic based on the knowledge-base."""
+from __future__ import annotations
+
+import csv
+from typing import Dict, List
+
+from config import KB_PATH
+
+
+# ---------------------------------------------------------------------------
+
+def load_knowledge_base(path: str | None = None) -> List[Dict[str, str]]:
+    """Load the knowledge-base CSV and return rows as dictionaries."""
+    path = path or str(KB_PATH)
+    rows: List[Dict[str, str]] = []
+    try:
+        with open(path, newline="", encoding="utf-8") as fp:
+            reader = csv.DictReader(fp)
+            for row in reader:
+                rows.append(row)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Error reading {path}: {exc}")
+    return rows
+
+
+# ---------------------------------------------------------------------------
+
+def decide(row: Dict[str, str]) -> str:
+    """Return BUY/SELL/HOLD decision based on RSI and MACD."""
+    try:
+        rsi = float(row.get("RSI_14", "nan"))
+        macd_hist = float(row.get("MACD_hist", "nan"))
+    except ValueError:
+        return "UNKNOWN"
+
+    if rsi < 30 and macd_hist > 0:
+        return "BUY"
+    if rsi > 70 and macd_hist < 0:
+        return "SELL"
+    return "HOLD"
+
+
+# ---------------------------------------------------------------------------
+
+def generate_decisions(path: str | None = None) -> Dict[str, str]:
+    """Generate a decision per asset from the knowledge base."""
+    rows = load_knowledge_base(path)
+    decisions: Dict[str, str] = {}
+    for row in rows:
+        asset = row.get("Crypto", "?")
+        decisions[asset] = decide(row)
+    return decisions
+
+
+if __name__ == "__main__":
+    for asset, decision in generate_decisions().items():
+        print(f"{asset}: {decision}")

--- a/master.py
+++ b/master.py
@@ -1,0 +1,88 @@
+"""Master script to run the entire data pipeline sequentially.
+
+This script loads the configured assets, fetches historical data from CoinGecko,
+computes indicators and updates the knowledge base. Any exception during a step
+is logged and the script continues with the next asset.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict
+
+from decision_maker import generate_decisions
+
+from config import CG_LOG_PATH, CRYPTOS_PATH
+from fetcher import get_market_chart
+from io_utils import write_asset_csv, init_kb, append_kb_row
+from processing import transform_json, enrich_indicators
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(), logging.FileHandler(CG_LOG_PATH)],
+)
+logger = logging.getLogger(__name__)
+
+
+def load_assets() -> Dict[str, Dict]:
+    """Load asset configuration from ``cryptos.json``."""
+    try:
+        with open(CRYPTOS_PATH, "r", encoding="utf-8") as fp:
+            return json.load(fp)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error("Failed loading %s – %s", CRYPTOS_PATH, exc)
+        return {}
+
+
+def run_pipeline() -> int:
+    """Run the entire pipeline sequentially for all configured assets."""
+    vs_currency = "usd"
+    days = "365"
+    interval = "daily"
+    rsi_windows = [7, 14, 21]
+
+    assets = load_assets()
+    if not assets:
+        logger.error("No assets to process – check %s", CRYPTOS_PATH)
+        return 1
+
+    init_kb(rsi_windows)
+
+    for symbol, info in assets.items():
+        try:
+            url = info.get("coingecko_id")
+            if not url:
+                logger.warning("Skipping %s – no CoinGecko URL", symbol)
+                continue
+
+            raw = get_market_chart(url, vs_currency, days, interval)
+            if not raw:
+                raise RuntimeError("empty data returned")
+
+            recs = transform_json(raw, symbol)
+            recs = enrich_indicators(recs, rsi_windows)
+
+            write_asset_csv(symbol, recs, rsi_windows, days)
+            append_kb_row(symbol, recs[-1], rsi_windows)
+            logger.info("%s processed (%d records)", symbol, len(recs))
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Failed processing %s – %s", symbol, exc)
+
+    logger.info("Pipeline complete")
+
+    # After pipeline, generate trading decisions from the knowledge base
+    try:
+        decisions = generate_decisions()
+        for asset, decision in decisions.items():
+            logger.info("Decision for %s: %s", asset, decision)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error("Failed generating decisions – %s", exc)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_pipeline())


### PR DESCRIPTION
## Summary
- add `decision_maker.py` for simple trading decisions based on RSI and MACD
- call the new decision logic at the end of `master.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python master.py`

------
https://chatgpt.com/codex/tasks/task_e_684473b7c2408328b5509ed0d383a109