### PR TITLE
Add OHLC and market cap data

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The script will:
 1. Load your asset list from `cryptos.json`.
 2. Rate-limit and download each asset’s data from CoinGecko.
 3. Compute SMA, EMA, RSI, Bollinger Bands, MACD, Momentum, Log-returns and OBV.
+   Daily OHLC values and market caps are also stored.
 4. Write a per-asset CSV in `data/<symbol>_365d.csv`.
 5. Append the latest snapshot for each asset to `knowledgebase.csv`.
 

--- a/cli.py
+++ b/cli.py
@@ -14,7 +14,7 @@ from config import (
     MOMENTUM_WINDOWS,
     LOG_RETURN_WINDOWS,
 )
-from fetcher import get_market_chart
+from fetcher import get_market_chart, get_ohlc
 from io_utils import write_asset_csv, init_kb, append_kb_row
 from processing import transform_json, enrich_indicators
 
@@ -53,10 +53,11 @@ def process_asset(
         return False
 
     raw = get_market_chart(url, vs_currency, days, interval)
+    ohlc = get_ohlc(url, vs_currency, days)
     if not raw:
         return False
 
-    recs = transform_json(raw, symbol)
+    recs = transform_json(raw, symbol, ohlc)
     recs = enrich_indicators(recs, rsi_windows)
 
     write_asset_csv(symbol, recs, rsi_windows, days)

--- a/io_utils.py
+++ b/io_utils.py
@@ -34,6 +34,7 @@ def write_asset_csv(
         "Low",
         "Price",
         "Volume",
+        "Market_Cap",
         "obv",
         "24h_Change",
         "1d_Return",
@@ -75,8 +76,12 @@ def init_kb(rsi_windows: List[int]):
     header = [
         "Crypto",
         "Date",
+        "Open",
+        "High",
+        "Low",
         "Price",
         "Volume",
+        "Market_Cap",
         "1d Return",
         "7d Return",
     ]
@@ -106,8 +111,12 @@ def append_kb_row(asset: str, latest: Dict[str, Any], rsi_windows: List[int]):
     row = [
         asset,
         latest["Date"],
+        latest.get("Open"),
+        latest.get("High"),
+        latest.get("Low"),
         latest["Price"],
         latest["Volume"],
+        latest.get("Market_Cap"),
         latest.get("1d_Return"),
         latest.get("7d_Return"),
     ]

--- a/master.py
+++ b/master.py
@@ -14,7 +14,7 @@ from typing import Dict
 from decision_maker import generate_decisions
 
 from config import CG_LOG_PATH, CRYPTOS_PATH
-from fetcher import get_market_chart
+from fetcher import get_market_chart, get_ohlc
 from io_utils import write_asset_csv, init_kb, append_kb_row
 from processing import transform_json, enrich_indicators
 
@@ -59,10 +59,11 @@ def run_pipeline() -> int:
                 continue
 
             raw = get_market_chart(url, vs_currency, days, interval)
+            ohlc = get_ohlc(url, vs_currency, days)
             if not raw:
                 raise RuntimeError("empty data returned")
 
-            recs = transform_json(raw, symbol)
+            recs = transform_json(raw, symbol, ohlc)
             recs = enrich_indicators(recs, rsi_windows)
 
             write_asset_csv(symbol, recs, rsi_windows, days)

--- a/processing.py
+++ b/processing.py
@@ -26,10 +26,12 @@ from config import (
 def transform_json(
     data: Dict[str, Any],
     asset: str,
+    ohlc: List[List[float]] | None = None,
 ) -> List[Dict[str, Any]]:
     """Convert CoinGecko *market_chart* response to list of dicts."""
     prices = data.get("prices", [])
     total_volumes = data.get("total_volumes", [])
+    market_caps = data.get("market_caps", [])
 
     records: list[dict[str, Any]] = []
     prev_price: float | None = None
@@ -44,13 +46,21 @@ def transform_json(
         pct_24h = None
         if prev_price and prev_price > 0:
             pct_24h = (price - prev_price) / prev_price * 100.0
-        records.append({
+        rec = {
             "Date": ts_str,
             "Price": price,
             "Volume": volume,
             "24h_Change": pct_24h,
             "crypto": asset,
-        })
+        }
+        if ohlc and idx < len(ohlc):
+            _, o_open, o_high, o_low, _ = ohlc[idx]
+            rec["Open"] = float(o_open)
+            rec["High"] = float(o_high)
+            rec["Low"] = float(o_low)
+        if idx < len(market_caps) and len(market_caps[idx]) > 1:
+            rec["Market_Cap"] = float(market_caps[idx][1])
+        records.append(rec)
         prev_price = price
     return records
 


### PR DESCRIPTION
## Summary
- extend `fetcher` with a new `get_ohlc` helper
- store open, high, low and market cap columns in CSVs and knowledgebase
- update processing to merge OHLC and market cap data
- modify CLI and master pipeline to fetch the new endpoint
- document the additional features in README

## Testing
- `pip install -r requirements.txt`
- `python master.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447e8265d4832887e2d6361b2369bd