### PR TITLE
Improve robustness and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The script will:
 1. Load your asset list from `cryptos.json`.
 2. Rate-limit and download each asset’s data from CoinGecko.
 3. Compute SMA, EMA, RSI, Bollinger Bands, MACD, Momentum, Log-returns and OBV.
+   Daily OHLC values and market caps are also stored.
 4. Write a per-asset CSV in `data/<symbol>_365d.csv`.
 5. Append the latest snapshot for each asset to `knowledgebase.csv`.
 

--- a/decision_maker.py
+++ b/decision_maker.py
@@ -18,7 +18,11 @@ def load_knowledge_base(path: str | None = None) -> List[Dict[str, str]]:
             reader = csv.DictReader(fp)
             for row in reader:
                 rows.append(row)
-    except Exception as exc:  # pylint: disable=broad-except
+    except FileNotFoundError as exc:
+        print(f"Knowledge base not found: {exc}")
+    except csv.Error as exc:
+        print(f"Malformed CSV in {path}: {exc}")
+    except OSError as exc:
         print(f"Error reading {path}: {exc}")
     return rows
 

--- a/io_utils.py
+++ b/io_utils.py
@@ -34,6 +34,7 @@ def write_asset_csv(
         "Low",
         "Price",
         "Volume",
+        "Market_Cap",
         "obv",
         "24h_Change",
         "1d_Return",
@@ -63,7 +64,7 @@ def write_asset_csv(
             for rec in records:
                 writer.writerow(rec)
         logging.info("Wrote %s", path)
-    except Exception as exc:  # pylint: disable=broad-except
+    except (OSError, csv.Error) as exc:
         logging.exception("Failed writing %s – %s", path, exc)
     return path
 
@@ -75,8 +76,12 @@ def init_kb(rsi_windows: List[int]):
     header = [
         "Crypto",
         "Date",
+        "Open",
+        "High",
+        "Low",
         "Price",
         "Volume",
+        "Market_Cap",
         "1d Return",
         "7d Return",
     ]
@@ -106,8 +111,12 @@ def append_kb_row(asset: str, latest: Dict[str, Any], rsi_windows: List[int]):
     row = [
         asset,
         latest["Date"],
+        latest.get("Open"),
+        latest.get("High"),
+        latest.get("Low"),
         latest["Price"],
         latest["Volume"],
+        latest.get("Market_Cap"),
         latest.get("1d_Return"),
         latest.get("7d_Return"),
     ]

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -1,0 +1,28 @@
+"""Minimal Telegram messaging helper."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+from config import TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
+
+
+def send_message(text: str) -> bool:
+    """Send *text* to configured Telegram chat if credentials available."""
+    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
+        return False
+
+    url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+    payload = {"chat_id": TELEGRAM_CHAT_ID, "text": text}
+    try:
+        response = requests.post(url, data=payload, timeout=10)
+        response.raise_for_status()
+        return True
+    except requests.exceptions.RequestException as exc:
+        logging.error("Failed sending Telegram message: %s", exc)
+        return False
+
+
+__all__ = ["send_message"]

--- a/tests/test_decision_maker.py
+++ b/tests/test_decision_maker.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from decision_maker import decide
+
+
+def test_decide_buy():
+    row = {"RSI_14": "25", "MACD_hist": "0.5"}
+    assert decide(row) == "BUY"
+
+
+def test_decide_sell():
+    row = {"RSI_14": "75", "MACD_hist": "-1"}
+    assert decide(row) == "SELL"
+
+
+def test_decide_hold():
+    row = {"RSI_14": "50", "MACD_hist": "0"}
+    assert decide(row) == "HOLD"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,32 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from processing import transform_json, validate_records, enrich_indicators
+
+
+def sample_raw():
+    return {
+        "prices": [[0, 1.0], [86400, 2.0]],
+        "total_volumes": [[0, 10], [86400, 20]],
+        "market_caps": [[0, 100], [86400, 200]],
+    }
+
+
+def sample_ohlc():
+    return [[0, 0.5, 1.5, 0.4, 1.0], [86400, 1.5, 2.2, 1.0, 2.0]]
+
+
+def test_transform_and_validate():
+    recs = transform_json(sample_raw(), "tst", sample_ohlc())
+    recs = validate_records(recs)
+    assert len(recs) == 2
+    assert recs[0]["Open"] == 0.5
+
+
+def test_enrich_indicators():
+    recs = transform_json(sample_raw(), "tst", sample_ohlc())
+    recs = validate_records(recs)
+    enriched = enrich_indicators(recs, [7])
+    # macd etc produce None for early rows; just check key exists
+    assert "macd" in enriched[-1]


### PR DESCRIPTION
## Summary
- refine exception handling across modules
- add Telegram notification helper and integrate into master
- validate records before enrichment
- introduce simple unit tests for decision making and processing

## Testing
- `pytest -q`
- `python master.py`

------
https://chatgpt.com/codex/tasks/task_e_68447e8265d4832887e2d6361b2369bd