### PR TITLE
Add conversation log with agent explanation

### DIFF
--- a/CONVERSATION_LOG.md
+++ b/CONVERSATION_LOG.md
@@ -1,0 +1,20 @@
+# Conversation Log
+
+This file summarizes a short interaction with an assistant about this repository.
+
+## 1. Explaining the Codebase
+The assistant provided a simplified overview for a young audience. Key points were:
+- The project is like a helper robot that fetches cryptocurrency prices.
+- It calculates indicators (averages, bands, etc.) to see if prices go up or down.
+- A decision part suggests whether to buy, sell, or hold.
+- Results are stored in CSV files, and the master script coordinates everything.
+
+## 2. Running the Master Script
+The assistant confirmed that running `python master.py` will:
+1. Install dependencies from `requirements.txt` if needed.
+2. Fetch market data for each asset listed in `cryptos.json`.
+3. Compute indicators and update CSV files and `knowledgebase.csv`.
+4. Generate trading decisions and optionally send a Telegram notification.
+
+The previous run logs are stored in `coingecko.log` and the newest snapshot is
+appended to `knowledgebase.csv`.


### PR DESCRIPTION
## Summary
- document a short conversation with the agent in `CONVERSATION_LOG.md`

## Testing
- `pytest -q`
- `python master.py`

------
https://chatgpt.com/codex/tasks/task_e_685020037a308328a14c89e0dadc1fd5